### PR TITLE
Update grafananotificationchannel_controller.go

### DIFF
--- a/controllers/grafananotificationchannel/grafananotificationchannel_controller.go
+++ b/controllers/grafananotificationchannel/grafananotificationchannel_controller.go
@@ -276,7 +276,10 @@ func (r *GrafanaNotificationChannelReconciler) reconcileNotificationChannels(req
 		if err := json.Unmarshal(processed, &rawJson); err != nil {
 			return reconcile.Result{}, err
 		}
-
+		if rawJson.UID == nil {
+			r.Log.Info(fmt.Sprintf("cannot process notificationchannel %v/%v, UID is nil", notificationchannel.Namespace, notificationchannel.Name))
+			return reconcile.Result{}, nil
+		}
 		if _, err = client.GetNotificationChannel(*rawJson.UID); err != nil {
 			status, err = client.CreateNotificationChannel(processed)
 		} else {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the changes, Please add any additional motivation and context as needed -->
Add uid verification
## Relevant issues/tickets
<!-- Please include a link to the issue or ticket that applies to this pull request, delete this heading if not relevant -->
[Bug] GrafanaNotificationChannel cr not have UID will cause the program to crash #747
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
<!-- Tick options that apply, in-code tests are not required but please provide test cases and list steps in "verification steps" with the steps you used to verify this -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
<!-- Please include a series of steps to verify that the functionality/bug fix works, ideally the steps you used to test these changes(if applicable, if not, delete this section)-->
![image](https://user-images.githubusercontent.com/19486917/167325975-00fd3df5-e903-4ee3-90bc-9cbd908788a0.png)

when i use this cr  to apply 
```
apiVersion: integreatly.org/v1alpha1
kind: GrafanaNotificationChannel
metadata:
  name: notifiers
  namespace: monitoring
  labels:
    app: grafana
spec:
  name: notifiers.json
  json: >
    {
      "name": "alertmanager-notification",
      "type": "prometheus-alertmanager",
      "frequency": "",
      "settings": {
        "uploadImage": false,
        "autoResolve": true,
        "httpMethod": "POST",
        "severity": "critical",
        "url": "http://192.168.115.49:9093/"
       }
    }
```
the code print this and not have crash
![image](https://user-images.githubusercontent.com/19486917/167326269-9622d453-9f3c-4835-8633-d6be6d0e0226.png)


